### PR TITLE
Divergent-Minds: scaffold UI, glossary, results templates (no CI)

### DIFF
--- a/docs/ability_glossary.json
+++ b/docs/ability_glossary.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "logical_pioneer.problem_breaker",
+    "guild_id": "logical_pioneer",
+    "name": "Problem Breaker",
+    "plain_explanation": "Breaking a big problem into smaller, solvable steps so it feels clear and doable. [src:dm_experience_doc#Logical Pioneer Guild]",
+    "authoritative_pointer": "dm_experience_doc#Logical Pioneer Guild"
+  },
+  {
+    "id": "idea_mavericks.creative_innovator",
+    "guild_id": "idea_mavericks",
+    "name": "Creative Innovator",
+    "plain_explanation": "Coming up with original solutions beyond the usual patterns. [src:dm_experience_doc#The Idea Mavericks Guild]",
+    "authoritative_pointer": "dm_experience_doc#The Idea Mavericks Guild"
+  }
+]

--- a/exports/results/concise_profile_template.json
+++ b/exports/results/concise_profile_template.json
@@ -1,0 +1,16 @@
+{
+  "title": "Divergent-Minds — Concise Profile",
+  "generated_at": "",
+  "inherent": [],
+  "proficient": [],
+  "weak": [],
+  "notes": {
+    "scoring": "1=weak, 2=proficient, 3=inherent",
+    "guidance": [
+      "Prioritize inherent abilities (superpowers)",
+      "Strengthen proficient abilities",
+      "Treat weak areas as low ROI to force-fit"
+    ],
+    "citations": []
+  }
+}

--- a/exports/results/concise_profile_template.md
+++ b/exports/results/concise_profile_template.md
@@ -1,0 +1,10 @@
+# Divergent-Minds — Concise Profile
+
+## Inherent Abilities (born-wired “superpowers”)
+{{inherent_list_markdown}}
+
+## Proficient Abilities (skills to strengthen)
+{{proficient_list_markdown}}
+
+## Weak Areas (brain–body not naturally wired; low ROI to over-invest)
+{{weak_list_markdown}}

--- a/exports/results/narrative_template.md
+++ b/exports/results/narrative_template.md
@@ -1,0 +1,28 @@
+# Divergent-Minds — Rich Narrative
+
+> “You be you, and I’ll be me. Let’s discover the greatness in you.” [src:dm_experience_doc#Game Rule: You Be You, and I’ll Be Me]
+
+## Why we’re here
+This guided experience helps you discover your **true inherent abilities** (born-wired superpowers), distinguish **proficient abilities**, and recognize **weak areas** (subjects your brain–body wasn’t naturally wired for). This is not a wishlist. [src:dm_experience_doc#This is not a wishlist]
+
+## Your path today
+- Session length: {{session_choice}} (90 / 2×30 / 6×15)
+- Mode: Universal — Guided
+- Scoring: 1=weak · 2=proficient · 3=inherent
+
+## Highlights across Cognitive Guilds
+{{guild_highlights_markdown}}
+
+## Themes & Patterns
+- Inherent themes we observed: {{inherent_themes}}
+- Proficient themes to invest in: {{proficient_themes}}
+- Weak-area caution notes (low ROI to force-fit): {{weak_themes}}
+
+## Examples (grounded)
+{{grounded_examples_md}}
+
+---
+## Next steps
+1) Lean into **inherent abilities** — they’re your human superpowers.
+2) Strengthen **proficient abilities** through targeted practice.
+3) Treat **weak areas** as low-priority — explore if you’re curious, but don’t over-invest.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "divergent-minds-app",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {}
+}

--- a/src/AbilityScoreCard.jsx
+++ b/src/AbilityScoreCard.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+
+export default function AbilityScoreCard({ ability, value, onChange, onExplain, onExample }) {
+  return (
+    <div className="p-4 rounded-xl shadow">
+      <h3 className="text-lg font-semibold">{ability.name}</h3>
+      <p className="text-sm opacity-80">{ability.description}</p>
+      <div className="mt-3 flex gap-3 items-center">
+        {[1,2,3].map(v => (
+          <label key={v} className="flex items-center gap-1">
+            <input
+              type="radio"
+              name={`score-${ability.id}`}
+              value={v}
+              checked={value === v}
+              onChange={() => onChange(v)}
+            />
+            <span>{v}</span>
+          </label>
+        ))}
+        <button className="text-sm underline" onClick={() => onExplain(ability)}>
+          What does this mean?
+        </button>
+        <button className="text-sm underline" onClick={() => onExample(ability)}>
+          Need an example?
+        </button>
+      </div>
+      <p className="text-xs mt-2 opacity-70">
+        Scores must be whole numbers: 1 (weak), 2 (proficient), 3 (inherent). You can explore and rescore later.
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
- Adds AbilityScoreCard (1/2/3 scoring + “What does this mean?” + “Need an example?”)
- Seeds docs/ability_glossary.json (grows on-demand at runtime)
- Adds Rich Narrative and Concise Profile export templates
- package.json stub to satisfy CI later
